### PR TITLE
No-longer necessary to import context package

### DIFF
--- a/dag/dagctx.go
+++ b/dag/dagctx.go
@@ -1,10 +1,9 @@
 package ctxext
 
 import (
+	"context"
 	"sync"
 	"time"
-
-	context "golang.org/x/net/context"
 )
 
 // WithParents returns a Context that listens to all given

--- a/dag/dagctx_test.go
+++ b/dag/dagctx_test.go
@@ -1,11 +1,10 @@
 package ctxext
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 	"time"
-
-	context "golang.org/x/net/context"
 )
 
 func TestWithParentsSingle(t *testing.T) {

--- a/frac/fracctx.go
+++ b/frac/fracctx.go
@@ -2,9 +2,8 @@
 package ctxext
 
 import (
+	"context"
 	"time"
-
-	context "golang.org/x/net/context"
 )
 
 // WithDeadlineFraction returns a Context with a fraction of the

--- a/frac/fracctx_test.go
+++ b/frac/fracctx_test.go
@@ -1,11 +1,10 @@
 package ctxext
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
-
-	context "golang.org/x/net/context"
 )
 
 // this test is on the context tool itself, not our stuff. it's for sanity on ours.
@@ -14,7 +13,8 @@ func TestDeadline(t *testing.T) {
 		t.Skip("timeouts don't work reliably on travis")
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cncl()
 
 	select {
 	case <-ctx.Done():
@@ -46,8 +46,10 @@ func TestDeadlineFractionHalf(t *testing.T) {
 		t.Skip("timeouts don't work reliably on travis")
 	}
 
-	ctx1, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	ctx2, _ := WithDeadlineFraction(ctx1, 0.5)
+	ctx1, cncl1 := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cncl1()
+	ctx2, cncl2 := WithDeadlineFraction(ctx1, 0.5)
+	defer cncl2()
 
 	select {
 	case <-ctx1.Done():

--- a/io/ctxio.go
+++ b/io/ctxio.go
@@ -11,9 +11,8 @@
 package ctxio
 
 import (
+	"context"
 	"io"
-
-	context "golang.org/x/net/context"
 )
 
 type ioret struct {

--- a/io/ctxio_test.go
+++ b/io/ctxio_test.go
@@ -2,11 +2,10 @@ package ctxio
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 	"time"
-
-	context "golang.org/x/net/context"
 )
 
 func TestReader(t *testing.T) {


### PR DESCRIPTION
* Since go 1.9 there is no need for importing context package from golang.org/x/net/context.
* With this PR the context package from the stdlib should work.
* calls the cancel functions for contexts in the test package.

As part of an internal package, there is a dependency on the jbenet/go-context package, along with a necessity of not being able to import golang.org/x/net/context package, since it is already available in the standard library. 

@jbenet please review and advise.